### PR TITLE
fix: resolve configuration mismatch between Settings.model and ClaudeClient

### DIFF
--- a/src/resume_customizer/core/claude_client.py
+++ b/src/resume_customizer/core/claude_client.py
@@ -49,6 +49,14 @@ class ClaudeClient:
             raise ValueError("Claude API key is required")
         
         self.settings = settings
+        
+        # Validate model exists in pricing dictionary
+        if settings.model not in CLAUDE_PRICING:
+            logger.warning(
+                f"Model '{settings.model}' not found in CLAUDE_PRICING dictionary. "
+                f"Cost calculations may be inaccurate. Supported models: {list(CLAUDE_PRICING.keys())}"
+            )
+        
         self.model_name = settings.model
         # Cap max_history_requests to prevent memory issues
         self.max_history_requests = min(getattr(settings, 'max_history_requests', 100), MAX_HISTORY_REQUESTS_LIMIT)

--- a/src/resume_customizer/core/claude_client.py
+++ b/src/resume_customizer/core/claude_client.py
@@ -20,6 +20,11 @@ MAX_HISTORY_REQUESTS_LIMIT = 1000
 
 # Pricing information for Claude models (per 1M tokens)
 CLAUDE_PRICING = {
+    "claude-3-5-sonnet-20241022": {
+        "input": 3.00,   # $3.00 per 1M input tokens
+        "output": 15.00  # $15.00 per 1M output tokens
+    },
+    # Legacy model name for backwards compatibility
     "claude-sonnet-4-0": {
         "input": 3.00,   # $3.00 per 1M input tokens
         "output": 15.00  # $15.00 per 1M output tokens
@@ -44,7 +49,7 @@ class ClaudeClient:
             raise ValueError("Claude API key is required")
         
         self.settings = settings
-        self.model_name = getattr(settings, 'model_name', 'claude-sonnet-4-0')
+        self.model_name = settings.model
         # Cap max_history_requests to prevent memory issues
         self.max_history_requests = min(getattr(settings, 'max_history_requests', 100), MAX_HISTORY_REQUESTS_LIMIT)
         self.usage_stats = {


### PR DESCRIPTION
### **User description**
## Summary
- Fixed configuration mismatch where ClaudeClient was looking for `settings.model_name` but Settings class has `model` field
- Updated CLAUDE_PRICING dictionary to include the correct model name
- Addresses critical issue #2 from code review recommendations

## Changes
- Changed `self.model_name = getattr(settings, 'model_name', 'claude-sonnet-4-0')` to `self.model_name = settings.model`
- Added 'claude-3-5-sonnet-20241022' to CLAUDE_PRICING dictionary
- Kept legacy model name for backwards compatibility

## Test plan
- [x] Ran unit tests - all 10 tests pass
- [x] Verified Settings.model field is accessible
- [x] Confirmed ClaudeClient correctly reads model name from settings

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed configuration mismatch between `Settings.model` and `ClaudeClient.model_name`

- Added correct model name to pricing dictionary

- Maintained backwards compatibility with legacy model


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Settings.model"] --> B["ClaudeClient.model_name"]
  C["CLAUDE_PRICING"] --> D["Added claude-3-5-sonnet-20241022"]
  E["Legacy model"] --> F["Backwards compatibility"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude_client.py</strong><dd><code>Fix model configuration and pricing dictionary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/resume_customizer/core/claude_client.py

<li>Fixed ClaudeClient to use <code>settings.model</code> instead of non-existent <br><code>settings.model_name</code><br> <li> Added 'claude-3-5-sonnet-20241022' to CLAUDE_PRICING dictionary<br> <li> Kept legacy model name for backwards compatibility


</details>


  </td>
  <td><a href="https://github.com/JoshuaOliphant/claude-resume-assistant/pull/15/files#diff-aef1c9b61c594566262f0b76fbdb40a525aace9b8420de0ce65af148aa2bc64c">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>